### PR TITLE
Update to Develocity Maven Extension

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       matrix:
         java: [8, 11, 17, 21]
     env:
-      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
     steps:
       - uses: actions/checkout@v3
 
@@ -91,7 +91,7 @@ jobs:
       matrix:
         zookeeper: [curator-test-zk38, curator-test-zk37, curator-test-zk36, curator-test-zk35]
     env:
-      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
     steps:
       - uses: actions/checkout@v3
 

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ atlassian-ide-plugin.xml
 # Gradle Enterprise
 test-reports/
 .mvn/.gradle-enterprise/
+.mvn/.develocity/

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -19,22 +19,17 @@
     under the License.
 
 -->
-<gradleEnterprise
-        xmlns="https://www.gradle.com/gradle-enterprise-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://www.gradle.com/gradle-enterprise-maven https://www.gradle.com/schema/gradle-enterprise-maven.xsd">
+<develocity
+        xmlns="https://www.gradle.com/develocity-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://www.gradle.com/develocity-maven https://www.gradle.com/schema/develocity-maven.xsd">
     <server>
         <url>https://ge.apache.org</url>
-        <allowUntrusted>false</allowUntrusted>
     </server>
     <buildScan>
-        <capture>
-            <goalInputFiles>true</goalInputFiles>
-            <buildLogging>true</buildLogging>
-            <testLogging>true</testLogging>
-        </capture>
         <backgroundBuildScanUpload>#{isFalse(env['GITHUB_ACTIONS'])}</backgroundBuildScanUpload>
-        <publish>ALWAYS</publish>
-        <publishIfAuthenticated>true</publishIfAuthenticated>
+        <publishing>
+            <onlyIf><![CDATA[authenticated]]></onlyIf>
+        </publishing>
         <obfuscation>
             <ipAddresses>#{{'0.0.0.0'}}</ipAddresses>
         </obfuscation>
@@ -47,4 +42,4 @@
             <enabled>false</enabled>
         </remote>
     </buildCache>
-</gradleEnterprise>
+</develocity>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -23,7 +23,7 @@
             xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
     <extension>
         <groupId>com.gradle</groupId>
-        <artifactId>gradle-enterprise-maven-extension</artifactId>
+        <artifactId>develocity-maven-extension</artifactId>
         <version>1.21.4</version>
     </extension>
     <extension>


### PR DESCRIPTION
@tisonkun - these are the changes you would need to make to migrate to the Develocity Maven Extension. This is functionally equivalent to what you have before, but using the new Develocity name rather than the deprecated Gradle Enterprise naming.